### PR TITLE
Fix rp2040_ce audio setup

### DIFF
--- a/keyboards/0xcb/newhorizons/rp2040_ce/config.h
+++ b/keyboards/0xcb/newhorizons/rp2040_ce/config.h
@@ -5,6 +5,9 @@
 
 #ifdef AUDIO_ENABLE
 #    define AUDIO_PIN GP12
+#    define AUDIO_PWM_DRIVER PWMD6
+#    define AUDIO_PWM_CHANNEL RP2040_PWM_CHANNEL_A
 #    define AUDIO_CLICKY
 #endif
+
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP17 // Specify a optional status led which blinks when entering the bootloader

--- a/keyboards/0xcb/newhorizons/rp2040_ce/halconf.h
+++ b/keyboards/0xcb/newhorizons/rp2040_ce/halconf.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#pragma once
+
+// Enable PWM for audio driver output
+#undef HAL_USE_PWM
+#define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/0xcb/newhorizons/rp2040_ce/info.json
+++ b/keyboards/0xcb/newhorizons/rp2040_ce/info.json
@@ -16,7 +16,7 @@
         "extrakey": true,
         "mousekey": true,
         "nkro": true,
-        "rgb_matrix": true,
+        "rgb_matrix": true
     },
     "ws2812": {
         "driver": "vendor",

--- a/keyboards/0xcb/newhorizons/rp2040_ce/mcuconf.h
+++ b/keyboards/0xcb/newhorizons/rp2040_ce/mcuconf.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef RP_PWM_USE_PWM6
+#define RP_PWM_USE_PWM6 TRUE

--- a/keyboards/0xcb/newhorizons/rp2040_ce/rules.mk
+++ b/keyboards/0xcb/newhorizons/rp2040_ce/rules.mk
@@ -1,0 +1,1 @@
+AUDIO_DRIVER = pwm_hardware


### PR DESCRIPTION
I noticed that trying to set `"audio": true` in `info.json` generates compile time errors when using a rp2040_ce controller like the Helios, so I started digging. 

> [!NOTE]
> Even with `"audio": true` in the `info.json`, the keyboard will not make sounds by default. You need to assign `CK_TOGG` in your keymap to enable/disable key sounds.


### What changed and why

- `halconf.h` is required to enable PWM inside the HAL
- `mcuconf.h` is required to select the correct PWM channel for GP12
- `rules.mk` to define the audio driver class used by
- `config.h` to configure the driver and and channel



